### PR TITLE
179-details-css

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import 'moment/locale/fr';
 import Tippy from '@tippy.js/react'
 import Link from 'next/link';
 import { cp_t, cp_post } from '../../helpers/commonProps';

--- a/components/stylesheets/PostContent.module.css
+++ b/components/stylesheets/PostContent.module.css
@@ -759,3 +759,7 @@
         height: 450px;
     }
   }
+
+  .postContent summary{
+    font-weight:600;
+  }


### PR DESCRIPTION
the original issue was a problem with a details box
we found out it works fine in prod, just broken in preview mode and in DEV mode (maybe the constant hot updates didnt sit too well with WET) anyways just added some bold.

the other fix was for the "from now" date to display in french, just needed an import