### PR TITLE
Change tags order on home page to show latest episodes.

### DIFF
--- a/pages/fr/index.js
+++ b/pages/fr/index.js
@@ -14,7 +14,7 @@ Index.getInitialProps = async function({req}) {
         page: 1,
         limit: 10,
         include: "tags,authors",
-        filter: `tag:${dictionary.getGhostLocaleTag}+tag:-hash-learning-path+tag:-hash-video`
+        filter: `tag:-hash-learning-path+tag:-hash-video+tag:${dictionary.getGhostLocaleTag}`
     };
     const posts = await getPosts(apiOptions);
     const settings = await getSettings();

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ Index.getInitialProps = async function({req}) {
         page: 1,
         limit: 10,
         include: "tags,authors",
-        filter: `tag:${dictionary.getGhostLocaleTag}+tag:-hash-learning-path+tag:-hash-video`
+        filter: `tag:-hash-learning-path+tag:-hash-video+tag:${dictionary.getGhostLocaleTag}`
     };
     const posts = await getPosts(apiOptions);
     const settings = await getSettings();


### PR DESCRIPTION
Quickfix : Homepage in english was not showing the latest episodes: Ghost api was not returning it.

Changed the tags order seems to fix the issue for now, to be invistigated later

before:
![image](https://user-images.githubusercontent.com/82387465/166697633-8d2681f0-6449-4256-9ffc-ad39ce527d63.png)

now:
![image](https://user-images.githubusercontent.com/82387465/166697555-68941ffd-6546-45da-b6cf-155f2c9aebd7.png)
