### PR TITLE
Hotfix - Render 404 errors

### DIFF
--- a/components/molecules/SnackBar.js
+++ b/components/molecules/SnackBar.js
@@ -45,7 +45,7 @@ export default function SnackBar(props) {
 
         return (
             <Snackbar open={showSnackBar} onClose={() => setShowSnackBar(false)} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
-                {snackBarContent &&
+                {snackBarContent && props.locale &&
                     <div className={styles.snackBar}>
                         <p>{snackBarContent.message[props.locale] + " "}
                             <a href={snackBarContent.links[props.locale].link}>{snackBarContent.links[props.locale].label}</a>


### PR DESCRIPTION
Fix when locale is not set for Snackbar, which causes the 404 error not to render
(ex: https://busrides-trajetsenbus.csps-efpc.gc.ca/tag/en-fwdthinking-series)